### PR TITLE
Checking for duplicate id in query

### DIFF
--- a/admin/views.py
+++ b/admin/views.py
@@ -897,6 +897,7 @@ def resource_edit(resource_type, resource_id):
 
     if resource_type == "mandi-receipt":
         existing_sale_receipt = SaleReceiptModel.query.filter(
+            SaleReceiptModel.id != resource.id,  # Ensure IDs do not match
             SaleReceiptModel.booklet_number == resource.booklet_number,
             SaleReceiptModel.receipt_id == resource.receipt_id,
             SaleReceiptModel.mandi_id == resource.mandi_id,
@@ -916,6 +917,7 @@ def resource_edit(resource_type, resource_id):
             resource.is_approved = False
             resource.token_amount = 0
 
+    db.session.add(resource)
     db.session.commit()
 
     # call after update hook


### PR DESCRIPTION
Targets https://gramhal.monday.com/boards/4834273983/pulses/5817291580

### Description
1. Added check for id when querying for existing sale receipt, so that we don't get the same receipt id
2. Added modified resource into db session before commit